### PR TITLE
Update to SED command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ export IMGPKG_REGISTRY_PASSWORD=$(kubectl get secret -n tap-gui private-registry
 After you're successfully authenticated, run the following command to get the Configurator image.
 ```
 export CONFIGURATOR_IMAGE=$(imgpkg describe -b $CONFIGURATOR_IMAGE_BUNDLE -o yaml --tty=true | grep -A 1 \
-"kbld.carvel.dev/id: harbor-repo.vmware.com/esback/configurator" | grep "image: " | sed 's/\simage: //g') && echo $CONFIGURATOR_IMAGE
+"kbld.carvel.dev/id: harbor-repo.vmware.com/esback/configurator" | grep "image: " | sed 's/^[[:space:]]*image: //g') && echo $CONFIGURATOR_IMAGE
 ```
 ##### Define and apply Workload
 [Documentation](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.7/tap/tap-gui-configurator-building.html#build-your-customized-portal-3)


### PR DESCRIPTION
Hi Timo, in my case the sed comment didn't remove spaces at the beginning of the string and also didn't remove "image: ". I ran into problems later with one of the ytt commands. I am not using the TAP dev environment but my own TAP installation, maybe check if you can use this updated sed command as well. After this update everything works as expected